### PR TITLE
feat: プロフィールページに項目を表示する

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,8 +30,25 @@ class User < ApplicationRecord
   end
 
   def display_name
-    self.email.split("@")[0]
+    # 以下のコードはネストされた条件演算子。
+    # profileがnilでなく、かつprofile.nicknameがnilでない場合はprofile.nicknameを返し、そうでない場合はself.email.split("@")[0]を返す
+    # if profile && profile.nickname
+    #   profile.nickname
+    # else
+    #   self.email.split("@")[0]
+    # end
+
+    # ボッチ演算子では上記のコードを以下のように書き換えることができる
+    profile&.nickname || self.email.split("@")[0]
     # -> ["cohki0305", "gmail.com"]
+  end
+
+  def birthday
+    profile&.birthday
+  end
+
+  def gender
+    profile&.gender
   end
 
   def prepare_profile

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -5,7 +5,8 @@
     .profilePage_user_basicInfo
       .profilePage_user_name
         .profilePage_user_displayName
-          = current_user.display_name
+          -# 以下の誕生日と性別については未入力の場合は表示がおかしくなるが、一旦保留にして後ほど解消する
+          #{current_user.display_name} (#{current_user.birthday}・#{current_user.gender})
         .profilePage_user_actionButton
           = link_to 'Edit', edit_profile_path
       .profilePage_user_introduction


### PR DESCRIPTION
- 誕生日と性別を表示する
  - #{}を用いて複数のメソッド経由の値を一列に出力
  - 未入力の場合は表示がおかしくなるが、一旦保留にして後ほど解消する
- 表示名についてリファクタリング
  - ボッチ演算子を使用して、プロフの存在まで見てニックネームなどを表示する処理を追加