### PR TITLE
feat: いいねを取り消せるようにする

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -9,4 +9,12 @@ class LikesController < ApplicationController
     article.likes.create!(user_id: current_user.id)
     redirect_to article_path(article)
   end
+
+  def destroy
+    article = Article.find(params[:article_id])
+    # find_byの!の内訳：!で絶対にいいねしている記事を探し出して削除。そもそもいいねしていない記事に対して削除できるわけがない
+    like = article.likes.find_by!(user_id: current_user.id)
+    like.destroy!
+    redirect_to article_path(article)
+  end
 end

--- a/app/views/articles/show.html.haml
+++ b/app/views/articles/show.html.haml
@@ -19,7 +19,9 @@
     -# いいねを押しているかどうかを判断する。押している場合は活性アイコン
     - if current_user.has_liked?(@article)
       .article_heart
-        = image_tag 'heart-active.svg'
+        -# いいねが押されている状態で再度ボタンを押したら、likesテーブル内のこの記事のレコードに対してdeleteリクエストを送信する
+        = link_to article_like_path(@article), data: { turbo_method: 'delete' } do
+          = image_tag 'heart-active.svg'
     - else
       -# いいねを押していない場合は非活性アイコン
       .article_heart

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
 
   resources :articles do
     resources :comments, only: [ :new, :create ]
-    resource :like, only: [ :create ]
+    resource :like, only: [ :create, :destroy ]
   end
 
   resource :profile, only: [ :show, :edit, :update ]


### PR DESCRIPTION
- routes.rbでdestroyのpathを追加
- likes_controller.rbでdestroyのメソッドを定義
- articles/show.html.hamlで、いいね済みのボタンを押したらdeleteリクエストを送信するようにする
  - なぜdeleteリクエストなのか：いいねを取り消すということは、likesテーブルからカラムを削除するような処理のため
  - フロント：いいねが解除されるUIにした
  - データベース：likesテーブルから対象の記事のレコードが削除された